### PR TITLE
increase suction release valve delay to 50ms

### DIFF
--- a/uarm_library.cpp
+++ b/uarm_library.cpp
@@ -687,6 +687,6 @@ void uArmClass::pumpOff()
    pinMode(VALVE_EN, OUTPUT);
    digitalWrite(VALVE_EN, HIGH);
    digitalWrite(PUMP_EN, LOW);
-   delay(20);
+   delay(50);
    digitalWrite(VALVE_EN,LOW);
 }


### PR DESCRIPTION
This is the implementation suggested by @ArifRahmanMY who demonstrated that the original suction release valve delay of 20ms is too short to fully release lighter items.

The increase to 50ms has been demonstrated and confirmed as a solution.
